### PR TITLE
fix view object not subscriptable

### DIFF
--- a/lib/splunkgen/savedsearches.py
+++ b/lib/splunkgen/savedsearches.py
@@ -126,8 +126,8 @@ def _alert(self, doc: dict) -> Mapping[str, dict]:
         'counttype': 'number of events'
     }
     # allow setting relation & quantity in savedsearches.conf
-    if doc.get('trigger') and type(doc['trigger']) == dict:
-        relation = doc['trigger'].keys()[0]
+    if doc.get('trigger') and isinstance(doc['trigger'], dict):
+        relation = list(doc['trigger'].keys())[0]
         ret['relation'] = relation
         ret['quantity'] = doc['trigger'][relation]
     else:


### PR DESCRIPTION
`relation = doc['trigger'].keys()[0]` returns a view object, not a list, which means it cannot be indexed directly with [0]. To fix this error and get the first key from the dictionary, convert the view object to a list first

this bug prevents us from changing the trigger condition, which is required to create alerts for data ingestion problems 